### PR TITLE
Fix adding timestamp fields to session get query

### DIFF
--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -8,5 +8,5 @@ module.exports = (sequelize) => {
 		},
 		expires: Sequelize.DataTypes.DATE,
 		data: Sequelize.DataTypes.TEXT,
-	});
+	}, { timestamps: false });
 };


### PR DESCRIPTION
This is possible solution of this [issue](https://github.com/traclabs/express-session-sequelize/issues/11).